### PR TITLE
CommitLintワークフローを追加

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,20 @@
+name: Lint Commits
+
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install commitlint
+        run: |
+          npm install --save-dev @commitlint/config-conventional @commitlint/cli
+          echo "module.exports = {extends: ['@commitlint/config-conventional'], defaultIgnores: false};" > commitlint.config.cjs
+
+      - name: Validate all commits in PR
+        run: |
+          npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
PR作成時にCommitLintによってコミットメッセージがConventionalCommitsルールに準拠しているかチェックするCIの追加

fixupなども禁止(`defaultIgnores: false`)し、コミットログをきれいに保つ