### PR TITLE
再生履歴・動画タイトルキャッシュをクリアする機能を追加

### DIFF
--- a/src/pages/Controller/components/Library/contexts/YouTubeDataContext/dbConfig.ts
+++ b/src/pages/Controller/components/Library/contexts/YouTubeDataContext/dbConfig.ts
@@ -1,9 +1,11 @@
+export const YOUTUBE_TITLE_STORE_NAME = "YouTubeTitle";
+
 export const dbConfig = {
   databaseName: "YouTube-VJ",
   version: 1,
   stores: [
     {
-      name: "YouTubeTitle",
+      name: YOUTUBE_TITLE_STORE_NAME,
       id: { keyPath: "videoId" },
       indices: [],
     },

--- a/src/pages/Controller/components/Library/contexts/YouTubeDataContext/hooks/useTitleCache.ts
+++ b/src/pages/Controller/components/Library/contexts/YouTubeDataContext/hooks/useTitleCache.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from "react";
+import setupIndexedDB, { useIndexedDBStore } from "use-indexeddb";
+import { YOUTUBE_TITLE_STORE_NAME, dbConfig } from "../dbConfig";
+import type { YouTubeTitleData } from "./useYouTubeTitleFetch";
+
+export const useTitleCache = () => {
+  const store = useIndexedDBStore<YouTubeTitleData>(YOUTUBE_TITLE_STORE_NAME);
+  const [count, setCount] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    await setupIndexedDB(dbConfig);
+    const all = await store.getAll();
+    setCount(all.length);
+  }, [store]);
+
+  const clear = useCallback(async () => {
+    await setupIndexedDB(dbConfig);
+    await store.deleteAll();
+    await refresh();
+  }, [store, refresh]);
+
+  return { count, refresh, clear };
+};

--- a/src/pages/Controller/components/Library/contexts/YouTubeDataContext/hooks/useYouTubeTitleFetch/index.ts
+++ b/src/pages/Controller/components/Library/contexts/YouTubeDataContext/hooks/useYouTubeTitleFetch/index.ts
@@ -1,6 +1,7 @@
 import { loadYouTubeIFrameAPI } from "@/components/VJPlayer/components/YouTubePlayer/utils";
 import { useCallback, useRef } from "react";
 import { useIndexedDBStore } from "use-indexeddb";
+import { YOUTUBE_TITLE_STORE_NAME } from "../../dbConfig";
 import fetchYouTubeTitle from "./utils";
 
 interface UseYouTubeTitleFetchReturn {
@@ -8,13 +9,13 @@ interface UseYouTubeTitleFetchReturn {
   addManually: (id: string, title: string) => void;
 }
 
-interface YouTubeTitleData {
+export interface YouTubeTitleData {
   videoId: string;
   title: string;
 }
 
 export const useYouTubeTitleFetch = (): UseYouTubeTitleFetchReturn => {
-  const indexedDBStore = useIndexedDBStore<YouTubeTitleData>("YouTubeTitle");
+  const indexedDBStore = useIndexedDBStore<YouTubeTitleData>(YOUTUBE_TITLE_STORE_NAME);
 
   const pendingRef = useRef<Map<string, Promise<string>>>(new Map());
 

--- a/src/pages/Controller/components/Settings/index.module.css
+++ b/src/pages/Controller/components/Settings/index.module.css
@@ -98,6 +98,10 @@
   margin-bottom: 24px;
 }
 
+.settingItem:last-child {
+  margin-bottom: 0;
+}
+
 .label {
   display: block;
   margin-bottom: 8px;
@@ -133,7 +137,7 @@
   color: rgb(150, 150, 150);
 }
 
-.saveButton {
+.actionButton {
   padding: 10px 16px;
   border: none;
   border-radius: 4px;
@@ -142,8 +146,11 @@
   cursor: pointer;
   transition: background-color 0.2s, opacity 0.2s;
   white-space: nowrap;
-  background-color: rgb(100, 150, 255);
   color: white;
+}
+
+.saveButton {
+  background-color: rgb(100, 150, 255);
 }
 
 .saveButton:hover {
@@ -152,6 +159,24 @@
 
 .saveButton:active {
   background-color: rgb(60, 110, 215);
+}
+
+.clearRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dangerButton {
+  background-color: rgb(200, 60, 60);
+}
+
+.dangerButton:hover {
+  background-color: rgb(180, 45, 45);
+}
+
+.dangerButton:active {
+  background-color: rgb(160, 35, 35);
 }
 
 .footer {

--- a/src/pages/Controller/components/Settings/index.tsx
+++ b/src/pages/Controller/components/Settings/index.tsx
@@ -1,3 +1,4 @@
+import { useTitleCache } from "@/pages/Controller/components/Library/contexts/YouTubeDataContext/hooks/useTitleCache";
 import { useControllerAPIContext } from "@/pages/Controller/contexts/ControllerAPIContext";
 import { useEffect } from "react";
 import discordIcon from "./discord-icon.svg";
@@ -9,7 +10,18 @@ interface SettingsProps {
 }
 
 const Settings = ({ isOpen, onClose }: SettingsProps) => {
-  const { settings, setSettings } = useControllerAPIContext();
+  const { settings, setSettings, historyAPI } = useControllerAPIContext();
+  const {
+    count: titleCacheCount,
+    refresh: refreshTitleCacheCount,
+    clear: clearTitleCache,
+  } = useTitleCache();
+
+  useEffect(() => {
+    if (isOpen) {
+      refreshTitleCacheCount();
+    }
+  }, [isOpen, refreshTitleCacheCount]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -59,6 +71,20 @@ const Settings = ({ isOpen, onClose }: SettingsProps) => {
       ...settings,
       youtubeDataAPIKey: e.target.value.trim() || null,
     });
+  };
+
+  const handleClearHistory = () => {
+    if (!window.confirm("再生履歴を削除しますか？")) {
+      return;
+    }
+    historyAPI.clear();
+  };
+
+  const handleClearTitleCache = async () => {
+    if (!window.confirm("動画タイトルキャッシュを削除しますか？")) {
+      return;
+    }
+    await clearTitleCache();
   };
 
   return (
@@ -113,6 +139,27 @@ const Settings = ({ isOpen, onClose }: SettingsProps) => {
                 onChange={handleChangeYoutubeDataAPIKey}
                 placeholder="APIキーを入力してください"
               />
+            </div>
+          </div>
+          <div className={styles.settingItem}>
+            <span className={styles.label}>データのクリア</span>
+            <div className={styles.clearRow}>
+              <button
+                type="button"
+                className={`${styles.actionButton} ${styles.dangerButton}`}
+                onClick={handleClearHistory}
+                title="再生履歴をクリアします"
+              >
+                履歴をクリア（{historyAPI.history.length}件）
+              </button>
+              <button
+                type="button"
+                className={`${styles.actionButton} ${styles.dangerButton}`}
+                onClick={handleClearTitleCache}
+                title="動画タイトルキャッシュをクリアします"
+              >
+                キャッシュをクリア（{titleCacheCount ?? "-"}件）
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #61

## Summary
- 設定パネルに「データのクリア」セクションを追加し、再生履歴・動画タイトルキャッシュ(IndexedDB)を個別にクリアできるようにした
- 各項目にクリア前の件数を表示し、クリア実行前に確認ダイアログを表示する
- ボタンにホバーツールチップを付け、クリア対象を明示
- Libraryを一度も開いていない状態でもIndexedDBが正しく初期化されるよう対応
- 動画タイトルキャッシュ(IndexedDB)アクセスを `YouTubeDataContext/hooks/useTitleCache` に集約

## Test plan
- [x] lint / format (biome) 通過
- [x] 型チェック (tsc) 通過
- [x] ビルド (vite build) 通過
- [x] 実ブラウザで設定パネルを開き、件数表示・クリア動作(履歴/キャッシュ)を確認
- [x] Libraryを一度も開いていない状態でのキャッシュクリアがフリーズしないことを確認