### PR TITLE
Chrome拡張機能ガイドへのリンクを追加

### DIFF
--- a/src/pages/Controller/components/Settings/index.module.css
+++ b/src/pages/Controller/components/Settings/index.module.css
@@ -185,7 +185,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  gap: 8px;
+  gap: 20px;
 }
 
 .footer .saveButton {
@@ -210,4 +210,18 @@
 .discordIcon {
   width: 20px;
   height: 20px;
+}
+
+.extensionLink {
+  display: flex;
+  align-items: center;
+  color: rgb(200, 200, 200);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.extensionLink:hover {
+  color: rgb(230, 230, 230);
 }

--- a/src/pages/Controller/components/Settings/index.tsx
+++ b/src/pages/Controller/components/Settings/index.tsx
@@ -161,6 +161,14 @@ const Settings = ({ isOpen, onClose }: SettingsProps) => {
         </div>
         <div className={styles.footer}>
           <a
+            href="/docs/chrome-extension.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.extensionLink}
+          >
+            Chrome拡張機能ガイド
+          </a>
+          <a
             href="https://discord.gg/6wNns5NXrs"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- 設定パネルの footer に Chrome 拡張機能マニュアル（`/docs/chrome-extension.html`）へのリンクを追加
- Discord コミュニティリンク（#74）と同じ footer に、同じパターンで追加

## Test plan
- [x] lint / format (biome) 通過
- [x] 型チェック (tsc) 通過（`midi-script-template.ts` のエラーは既存の generated ファイル未生成による無関係な事前既存エラー）