### PR TITLE
ci: fixupコミットを検出するworkflowを追加

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,10 +10,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install commitlint
-        run: |
-          npm install --save-dev @commitlint/config-conventional @commitlint/cli
-          echo "module.exports = {extends: ['@commitlint/config-conventional'], defaultIgnores: false};" > commitlint.config.cjs
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Validate all commits in PR
         run: |

--- a/.github/workflows/no-fixup-commits.yml
+++ b/.github/workflows/no-fixup-commits.yml
@@ -1,0 +1,39 @@
+name: no-fixup-commits
+
+on:
+  pull_request:
+
+jobs:
+  no-fixup-commits:
+    name: no-fixup-commits
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t subjects < <(git log --format=%s "${BASE_SHA}..${HEAD_SHA}")
+
+          if [ "${#subjects[@]}" -eq 0 ]; then
+            echo "No commits to check."
+            exit 0
+          fi
+
+          status=0
+
+          for s in "${subjects[@]}"; do
+            if [[ "$s" =~ ^(fixup|squash)! ]]; then
+              echo "::error::Auto-squash commit found: $s"
+              status=1
+            fi
+          done
+
+          exit $status


### PR DESCRIPTION
## Summary
- 既存の `commitlint.yml` (Lint Commits) は PR 全体を commitlint で検証しているが、`fixup!` / `squash!` プレフィックス付きコミット (マージ前に autosquash されるべき一時コミット) を弾けない既存 Issue があった
- `no-fixup-commits.yml` を追加し、PR 内の各コミット subject が `^(fixup|squash)!` で始まっていないかを明示的にチェックするようにした
- `commitlint.yml` は release-please がコミットメッセージから正しくバージョンを判定できるよう、Conventional Commits 形式の検証として引き続き併用する
- ローカルの commit-msg フック (`.husky/commit-msg` 経由の commitlint) による Conventional Commits 形式チェックは変更していない

Closes #22

## Test plan
- [ ] この PR 自体で `no-fixup-commits` / `commitlint` の両 workflow が正常に実行され pass すること