### PR TITLE
Deckの初期状態を黒画面に変更(固定動画の自動ロードを廃止)

### DIFF
--- a/src/components/VJPlayer/index.module.css
+++ b/src/components/VJPlayer/index.module.css
@@ -1,3 +1,9 @@
+.blackLayer {
+  position: absolute;
+  inset: 0;
+  background: #000;
+}
+
 .playerLayer {
   position: absolute;
   inset: 0;

--- a/src/components/VJPlayer/index.tsx
+++ b/src/components/VJPlayer/index.tsx
@@ -42,6 +42,7 @@ const VJPlayer = forwardRef<VJPlayerRef, VJPlayerProps>(
     );
 
     syncDataRef.current = syncData;
+    const isYouTubeSource = syncData.source.type === "youtube";
     const isUrlSource = syncData.source.type === "url";
     isUrlSourceRef.current = isUrlSource;
 
@@ -135,12 +136,13 @@ const VJPlayer = forwardRef<VJPlayerRef, VJPlayerProps>(
     }, []);
 
     useLayoutEffect(() => {
-      if (isUrlSource) {
+      if (!isYouTubeSource) {
         youtubePlayerRef.current?.pause();
-      } else {
+      }
+      if (!isUrlSource) {
         urlPlayerRef.current?.pause();
       }
-    }, [isUrlSource]);
+    }, [isYouTubeSource, isUrlSource]);
 
     useLayoutEffect(() => {
       notifySyncData(syncData);
@@ -164,14 +166,15 @@ const VJPlayer = forwardRef<VJPlayerRef, VJPlayerProps>(
     );
 
     const youtubeVideoId =
-      !isUrlSource && syncData.source.type === "youtube" ? syncData.source.videoId : null;
+      isYouTubeSource && syncData.source.type === "youtube" ? syncData.source.videoId : null;
     const urlSource = isUrlSource && syncData.source.type === "url" ? syncData.source.url : null;
 
     return (
       <div className={className}>
-        <div className={styles.playerLayer} style={{ display: isUrlSource ? "none" : "block" }}>
+        <div className={styles.blackLayer} />
+        <div className={styles.playerLayer} style={{ display: isYouTubeSource ? "block" : "none" }}>
           <YouTubePlayer
-            active={!isUrlSource}
+            active={isYouTubeSource}
             videoId={youtubeVideoId}
             playbackIntent={playbackIntent}
             onInterfaceReady={handleYouTubeInterfaceReady}

--- a/src/components/VJPlayer/types/index.ts
+++ b/src/components/VJPlayer/types/index.ts
@@ -23,7 +23,11 @@ export type PlaybackIntent = {
   playbackRate: number;
 };
 
-export type VideoSource = { type: "youtube"; videoId: string } | { type: "url"; url: string };
+export type LoadableVideoSource =
+  | { type: "youtube"; videoId: string }
+  | { type: "url"; url: string };
+
+export type VideoSource = LoadableVideoSource | { type: "none" };
 
 export type VJSyncData = {
   source: VideoSource;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,6 @@ export const LOCAL_STORAGE_KEY = {
 };
 
 export const DEFAULT_VALUES = {
-  videoId: "BLeUas72Mzk",
   syncKey: "vj-player-default",
   playbackRate: 1,
   volume: 100,
@@ -17,7 +16,7 @@ export const DEFAULT_VALUES = {
 } as const;
 
 export const INITIAL_SYNC_DATA = {
-  source: { type: "youtube" as const, videoId: DEFAULT_VALUES.videoId },
+  source: { type: "none" as const },
   playbackRate: DEFAULT_VALUES.playbackRate,
   currentTime: 0,
   baseTime: 0,

--- a/src/pages/Controller/components/Deck/index.module.css
+++ b/src/pages/Controller/components/Deck/index.module.css
@@ -18,6 +18,17 @@
   display: block;
 }
 
+.emptyLabel {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
+  pointer-events: none;
+}
+
 /* YouTube 表示中のファイル D&D 中のみ iframe 手前で drop を受ける */
 .playerDropCapture {
   position: absolute;

--- a/src/pages/Controller/components/Deck/index.tsx
+++ b/src/pages/Controller/components/Deck/index.tsx
@@ -47,6 +47,7 @@ const Deck = ({ localStorageKey, deckId, className, initialPaused = false }: Dec
     onDropStart: handleVideoDropStart,
   } = useFileDropOverlay({ filesOnly: true });
   const isYouTubeSource = syncData.source.type === "youtube";
+  const isEmptySource = syncData.source.type === "none";
 
   const getCurrentTime = (): number => {
     return vjPlayerRef.current?.getCurrentTime() ?? 0;
@@ -163,6 +164,7 @@ const Deck = ({ localStorageKey, deckId, className, initialPaused = false }: Dec
           events={vjPlayerEvents}
           syncKey={localStorageKey}
         />
+        {isEmptySource && <div className={styles.emptyLabel}>Load a video to start</div>}
         {isFileDragActive && isYouTubeSource && (
           <div
             className={styles.playerDropCapture}

--- a/src/pages/Controller/components/Mixer/components/PreparedVideoThumbnail/index.tsx
+++ b/src/pages/Controller/components/Mixer/components/PreparedVideoThumbnail/index.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_VALUES } from "@/constants";
 import type { VideoItem } from "@/pages/Controller/types/videoItem";
 import { getPreparedVideoUrl, getYouTubeVideoId } from "@/pages/Controller/utils/videoItem";
 import styles from "./index.module.css";
@@ -27,13 +26,7 @@ const PreparedVideoThumbnail = ({ preparedVideo }: PreparedVideoThumbnailProps) 
     );
   }
 
-  return (
-    <img
-      className={styles.thumbnail}
-      alt="YouTube Thumbnail"
-      src={`https://img.youtube.com/vi/${DEFAULT_VALUES.videoId}/default.jpg`}
-    />
-  );
+  return <div className={styles.thumbnail} />;
 };
 
 export default PreparedVideoThumbnail;

--- a/src/pages/Controller/types/videoItem.ts
+++ b/src/pages/Controller/types/videoItem.ts
@@ -1,7 +1,7 @@
-import type { VideoSource } from "@/components/VJPlayer/types";
+import type { LoadableVideoSource } from "@/components/VJPlayer/types";
 
 export type VideoItem = {
-  source: VideoSource;
+  source: LoadableVideoSource;
   title?: string;
   start?: number;
 };


### PR DESCRIPTION
## Summary
- Deck / VJPlayer の初期状態(`INITIAL_SYNC_DATA`)が特定のYouTube動画(`BLeUas72Mzk`)を自動ロードしていた挙動を廃止し、動画なし(黒画面)から開始するように変更
- ローカルファイル再生に対応した現在、YouTube固定のデフォルト動画を持つ理由がなくなったため
- `VideoSource` に `{type:"none"}` を追加し、Deck の Load 操作で初めて動画がセットされるようにした
- Controller側の Deck には「Load a video to start」というプレースホルダーを黒背景に重ねて表示(Projection側は黒画面のまま)
- Mixerの Prepared Video サムネイルが未選択時に黒背景の空表示になるよう変更

## Test plan
- [x] `npm run qa` (fix / type-check / build) が通ることを確認
- [x] `npm run dev` で起動し、Controller起動直後に両Deckが黒画面+プレースホルダー表示になることを確認
- [x] YouTube動画・ローカルファイルのLoadが従来通り動作することを確認