### PR TITLE
設定パネルにアプリのバージョンを表示

### DIFF
--- a/src/pages/Controller/components/Settings/index.module.css
+++ b/src/pages/Controller/components/Settings/index.module.css
@@ -188,6 +188,15 @@
   gap: 20px;
 }
 
+.version {
+  position: absolute;
+  right: 16px;
+  bottom: 12px;
+  color: rgb(120, 120, 120);
+  font-size: 11px;
+  pointer-events: none;
+}
+
 .footer .saveButton {
   min-width: 80px;
 }

--- a/src/pages/Controller/components/Settings/index.tsx
+++ b/src/pages/Controller/components/Settings/index.tsx
@@ -178,6 +178,10 @@ const Settings = ({ isOpen, onClose }: SettingsProps) => {
             Discordコミュニティに参加する
           </a>
         </div>
+        <span className={styles.version}>
+          v{__APP_VERSION__}
+          {__APP_RELEASE_DATE__ && ` (${__APP_RELEASE_DATE__})`}
+        </span>
       </div>
     </>
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __APP_RELEASE_DATE__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,14 @@
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
+
+const changelog = readFileSync(new URL('./CHANGELOG.md', import.meta.url), 'utf-8')
+const releaseLine = changelog
+  .split('\n')
+  .find((line) => line.startsWith(`## [${packageJson.version}]`))
+const releaseDateMatch = releaseLine?.match(/\((\d{4}-\d{2}-\d{2})\)/)
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,5 +17,9 @@ export default defineConfig({
     alias: {
       '@': '/src',
     },
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
+    __APP_RELEASE_DATE__: JSON.stringify(releaseDateMatch?.[1] ?? ''),
   },
 })


### PR DESCRIPTION
## 背景

設定パネルからアプリの現在バージョンを確認できるようにしたい。

## 変更内容

- `vite.config.ts` の `define` で package.json の version をグローバル定数 `__APP_VERSION__` として注入
- Settings パネルの footer にバージョン (`v1.4.0` 等) を表示

## Test plan

- [x] `npm run type-check`
- [x] `npm run check` (Biome)
- [x] `npm run build`