### PR TITLE
perf: シークバーの不要な再レンダリングを削減

### DIFF
--- a/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
+++ b/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
@@ -12,7 +12,6 @@ interface SeekBarProps {
 
 const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }: SeekBarProps) => {
   const [isHovering, setIsHovering] = useState(false);
-  const [cursorPosition, setCursorPosition] = useState(0);
   const [displayTime, setDisplayTime] = useState(currentTimeFunc());
   const duration = durationFunc();
 
@@ -20,6 +19,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
   const indicatorRef = useRef<HTMLDivElement>(null);
   const currentTimeRef = useRef(displayTime);
   const isHoveringRef = useRef(isHovering);
+  const cursorPositionRef = useRef(0);
 
   useEffect(() => {
     isHoveringRef.current = isHovering;
@@ -31,6 +31,14 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
     let animationId: number;
     let lastDisplaySecond = Math.floor(currentTimeFunc());
 
+    const updateIndicator = (position: number) => {
+      if (!indicatorRef.current) {
+        return;
+      }
+      const indicatorPosition = isHoveringRef.current ? cursorPositionRef.current * 100 : position;
+      indicatorRef.current.style.left = `${indicatorPosition}%`;
+    };
+
     const update = () => {
       const time = currentTimeFunc();
       currentTimeRef.current = time;
@@ -41,9 +49,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       if (barRef.current) {
         barRef.current.style.width = `${position}%`;
       }
-      if (indicatorRef.current && !isHoveringRef.current) {
-        indicatorRef.current.style.left = `${position}%`;
-      }
+      updateIndicator(position);
 
       const currentSecond = Math.floor(time);
       if (currentSecond !== lastDisplaySecond) {
@@ -60,18 +66,9 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
     };
   }, [currentTimeFunc, durationFunc]);
 
-  // hover中はカーソル位置、非hover中は再生位置をindicatorに反映する
-  useEffect(() => {
-    if (!indicatorRef.current || !isHovering) {
-      return;
-    }
-    indicatorRef.current.style.left = `${cursorPosition * 100}%`;
-  }, [isHovering, cursorPosition]);
-
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     const { width, left } = e.currentTarget.getBoundingClientRect();
-    const position = (e.clientX - left) / width;
-    setCursorPosition(position);
+    cursorPositionRef.current = (e.clientX - left) / width;
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -85,7 +82,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       className={styles.seekBar}
       onMouseEnter={() => setIsHovering(true)}
       onMouseMove={handleMouseMove}
-      onClick={() => onSeek(cursorPosition * duration)}
+      onClick={() => onSeek(cursorPositionRef.current * duration)}
       onMouseLeave={() => setIsHovering(false)}
       onKeyDown={handleKeyDown}
       tabIndex={0}

--- a/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
+++ b/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import styles from "./index.module.css";
-import { formatTime } from "./utils";
+import { formatTime, toPercentage } from "./utils";
 
 interface SeekBarProps {
   currentTimeFunc: () => number;
@@ -39,7 +39,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       currentTimeRef.current = time;
 
       const currentDuration = durationFunc();
-      const position = currentDuration > 0 ? (time / currentDuration) * 100 : 0;
+      const position = toPercentage(time, currentDuration);
 
       if (barRef.current) {
         barRef.current.style.width = `${position}%`;
@@ -100,7 +100,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
           <span
             key={cueId}
             className={styles.hotcue}
-            style={{ left: `${(time / duration) * 100}%` }}
+            style={{ left: `${toPercentage(time, duration)}%` }}
           >
             {cueId}
           </span>
@@ -111,7 +111,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
           <span
             key={marker}
             className={styles.loopMarker}
-            style={{ left: `${(marker / duration) * 100}%` }}
+            style={{ left: `${toPercentage(marker, duration)}%` }}
           >
             |
           </span>

--- a/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
+++ b/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./index.module.css";
 import { formatTime } from "./utils";
 
@@ -15,13 +15,42 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
   const [cursorPosition, setCursorPosition] = useState(0);
   const [displayTime, setDisplayTime] = useState(currentTimeFunc());
   const duration = durationFunc();
-  const position = duration > 0 ? (displayTime / duration) * 100 : 0;
+
+  const barRef = useRef<HTMLDivElement>(null);
+  const indicatorRef = useRef<HTMLDivElement>(null);
+  const currentTimeRef = useRef(displayTime);
+  const isHoveringRef = useRef(isHovering);
 
   useEffect(() => {
+    isHoveringRef.current = isHovering;
+  }, [isHovering]);
+
+  // barの幅とindicatorの再生位置は毎フレーム変化するため、
+  // Reactの再レンダリングを介さずrefで直接DOM操作する
+  useEffect(() => {
     let animationId: number;
+    let lastDisplaySecond = Math.floor(currentTimeFunc());
 
     const update = () => {
-      setDisplayTime(currentTimeFunc());
+      const time = currentTimeFunc();
+      currentTimeRef.current = time;
+
+      const currentDuration = durationFunc();
+      const position = currentDuration > 0 ? (time / currentDuration) * 100 : 0;
+
+      if (barRef.current) {
+        barRef.current.style.width = `${position}%`;
+      }
+      if (indicatorRef.current && !isHoveringRef.current) {
+        indicatorRef.current.style.left = `${position}%`;
+      }
+
+      const currentSecond = Math.floor(time);
+      if (currentSecond !== lastDisplaySecond) {
+        lastDisplaySecond = currentSecond;
+        setDisplayTime(time);
+      }
+
       animationId = requestAnimationFrame(update);
     };
 
@@ -29,7 +58,15 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
     return () => {
       cancelAnimationFrame(animationId);
     };
-  }, [currentTimeFunc]);
+  }, [currentTimeFunc, durationFunc]);
+
+  // hover中はカーソル位置、非hover中は再生位置をindicatorに反映する
+  useEffect(() => {
+    if (!indicatorRef.current || !isHovering) {
+      return;
+    }
+    indicatorRef.current.style.left = `${cursorPosition * 100}%`;
+  }, [isHovering, cursorPosition]);
 
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     const { width, left } = e.currentTarget.getBoundingClientRect();
@@ -39,7 +76,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-      onSeek(displayTime + (e.key === "ArrowRight" ? 1 : -1));
+      onSeek(currentTimeRef.current + (e.key === "ArrowRight" ? 1 : -1));
     }
   };
 
@@ -57,12 +94,8 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       aria-valuemax={duration}
       aria-valuenow={displayTime}
     >
-      <div className={styles.bar} data-seek-bar style={{ width: `${position}%` }} />
-      <div
-        className={styles.indicator}
-        data-seek-indicator
-        style={{ left: `${isHovering ? cursorPosition * 100 : position}%` }}
-      />
+      <div className={styles.bar} data-seek-bar ref={barRef} />
+      <div className={styles.indicator} data-seek-indicator ref={indicatorRef} />
       <div className={styles.time} data-seek-time>
         <span>{formatTime(displayTime)}</span>
         <span>{formatTime(duration)}</span>

--- a/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
+++ b/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
@@ -11,19 +11,13 @@ interface SeekBarProps {
 }
 
 const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }: SeekBarProps) => {
-  const [isHovering, setIsHovering] = useState(false);
   const [displayTime, setDisplayTime] = useState(currentTimeFunc());
   const duration = durationFunc();
 
   const barRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
   const currentTimeRef = useRef(displayTime);
-  const isHoveringRef = useRef(isHovering);
-  const cursorPositionRef = useRef(0);
-
-  useEffect(() => {
-    isHoveringRef.current = isHovering;
-  }, [isHovering]);
+  const cursorPositionRef = useRef<number | null>(null);
 
   // barの幅とindicatorの再生位置は毎フレーム変化するため、
   // Reactの再レンダリングを介さずrefで直接DOM操作する
@@ -35,7 +29,8 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       if (!indicatorRef.current) {
         return;
       }
-      const indicatorPosition = isHoveringRef.current ? cursorPositionRef.current * 100 : position;
+      const indicatorPosition =
+        cursorPositionRef.current !== null ? cursorPositionRef.current * 100 : position;
       indicatorRef.current.style.left = `${indicatorPosition}%`;
     };
 
@@ -66,9 +61,9 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
     };
   }, [currentTimeFunc, durationFunc]);
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+  const getPositionFromEvent = (e: React.MouseEvent<HTMLDivElement>): number => {
     const { width, left } = e.currentTarget.getBoundingClientRect();
-    cursorPositionRef.current = (e.clientX - left) / width;
+    return (e.clientX - left) / width;
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -80,10 +75,13 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
   return (
     <div
       className={styles.seekBar}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseMove={handleMouseMove}
-      onClick={() => onSeek(cursorPositionRef.current * duration)}
-      onMouseLeave={() => setIsHovering(false)}
+      onMouseMove={(e) => {
+        cursorPositionRef.current = getPositionFromEvent(e);
+      }}
+      onClick={(e) => onSeek(getPositionFromEvent(e) * duration)}
+      onMouseLeave={() => {
+        cursorPositionRef.current = null;
+      }}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="slider"

--- a/src/pages/Controller/components/Deck/components/SeekBar/utils/index.ts
+++ b/src/pages/Controller/components/Deck/components/SeekBar/utils/index.ts
@@ -3,3 +3,7 @@ export const formatTime = (seconds: number) => {
   const remainingSeconds = Math.floor(seconds % 60);
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
 };
+
+export const toPercentage = (value: number, total: number): number => {
+  return total > 0 ? (value / total) * 100 : 0;
+};

--- a/src/pages/Controller/components/Deck/index.tsx
+++ b/src/pages/Controller/components/Deck/index.tsx
@@ -49,9 +49,9 @@ const Deck = ({ localStorageKey, deckId, className, initialPaused = false }: Dec
   const isYouTubeSource = syncData.source.type === "youtube";
   const isEmptySource = syncData.source.type === "none";
 
-  const getCurrentTime = (): number => {
+  const getCurrentTime = useCallback((): number => {
     return vjPlayerRef.current?.getCurrentTime() ?? 0;
-  };
+  }, []);
 
   const updateSyncData = useCallback(
     (partialSyncData: Partial<VJSyncData>) => {
@@ -122,6 +122,10 @@ const Deck = ({ localStorageKey, deckId, className, initialPaused = false }: Dec
     deckAPIRef.current?.setPlaybackRate(playbackRate);
   }, [playbackRate, deckAPIRef]);
 
+  const getDuration = useCallback((): number => {
+    return deckAPIRef.current?.getDuration() ?? 0;
+  }, [deckAPIRef]);
+
   const vjPlayerEvents = useMemo(
     () => ({
       onPaused: () => {
@@ -176,7 +180,7 @@ const Deck = ({ localStorageKey, deckId, className, initialPaused = false }: Dec
       </div>
       <SeekBar
         currentTimeFunc={getCurrentTime}
-        durationFunc={() => deckAPIRef.current?.getDuration() ?? 0}
+        durationFunc={getDuration}
         hotCues={hotCues}
         loopMarkers={loopMarkers}
         onSeek={(time: number) => deckAPIRef.current?.seekTo(time)}


### PR DESCRIPTION
## 概要

再生中のシークバー(`SeekBar`)が毎フレーム無条件に React 再レンダリングされていた問題を解消する。

- `.bar`/`.indicator` の位置更新を ref 経由の直接 DOM 操作に変更し、`requestAnimationFrame` ループのたびに `SeekBar` 全体（`hotCues`/`loopMarkers` の `.map()` 含む）が再計算されるのを防止
- 時刻表示テキストは秒が変わったときだけ `setState` するよう変更
- hover 中のマウス移動・hover の enter/leave でも同様に再レンダリングが発生していたため、カーソル位置を state ではなく nullable な ref (`cursorPositionRef`) で管理する形に統一
- `Deck` 側の `getCurrentTime` を `useCallback` で安定化し、無関係な state 変化での `SeekBar` 側 `useEffect` の不要な teardown/再構築を防止

## 動作確認

- `npm run fix` (biome) / `npm run type-check` がパスすることを確認
