### PR TITLE
動画未ロード時にcurrentTimeが進み続けるバグを修正

### DIFF
--- a/src/components/VJPlayer/hooks/useTimeSync/index.ts
+++ b/src/components/VJPlayer/hooks/useTimeSync/index.ts
@@ -16,7 +16,7 @@ export const useTimeSync = (syncDataRef: RefObject<VJSyncData>) => {
   const getExpectedCurrentTime = useCallback((): number | null => {
     const syncData = syncDataRef.current;
 
-    if (syncData.baseTime === 0) {
+    if (syncData.source.type === "none" || syncData.baseTime === 0) {
       return null;
     }
 

--- a/src/components/VJPlayer/utils/index.ts
+++ b/src/components/VJPlayer/utils/index.ts
@@ -2,7 +2,7 @@ import type { VJSyncData, VideoSource } from "../types";
 
 /** sync の実効再生位置（秒）。paused / baseTime 未設定時は currentTime を返す */
 export const getEffectiveSyncTime = (sync: VJSyncData): number => {
-  if (sync.paused || sync.baseTime === 0) {
+  if (sync.paused || sync.baseTime === 0 || sync.source.type === "none") {
     return sync.currentTime;
   }
   const timeSinceUpdate = (Date.now() - sync.baseTime) / 1000;


### PR DESCRIPTION
## Summary

- Deck に動画が一切ロードされていない (`syncData.source.type === "none"`) 状態でも、SeekBar の `currentTime` 表示が時間経過とともに進み続けてしまう不具合を修正
- 原因: Deck マウント時の playbackRate 同期用 `useEffect` が無条件に `baseTime` を現在時刻で書き換えており、`source.type` が `"none"` のまま `paused: false` かつ `baseTime` が非ゼロになることで、時刻計算ロジック (`getExpectedCurrentTime` / `getEffectiveSyncTime`) が経過時間を加算し続けていた
- `source.type === "none"` の場合は経過時間計算を行わないよう、上記2関数にガードを追加

## Test plan

- [x] `npm run type-check`
- [x] `npm run check` (biome)
- [x] 動作確認（報告者にて実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)