### PR TITLE
fix: CHANGELOGのバージョン解析をcocogitto形式に対応

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,8 @@ const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.met
 const changelog = readFileSync(new URL('./CHANGELOG.md', import.meta.url), 'utf-8')
 const releaseLine = changelog
   .split('\n')
-  .find((line) => line.startsWith(`## [${packageJson.version}]`))
-const releaseDateMatch = releaseLine?.match(/\((\d{4}-\d{2}-\d{2})\)/)
+  .find((line) => line.startsWith(`## [v${packageJson.version}]`))
+const releaseDateMatch = releaseLine?.match(/(\d{4}-\d{2}-\d{2})\s*$/)
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- release-please から cocogitto への移行に伴い CHANGELOG.md の見出しフォーマットが変わり(`v` プレフィックス付きバージョン + 丸括弧なし日付)、`vite.config.ts` の `__APP_VERSION__` / `__APP_RELEASE_DATE__` 抽出処理が動作しなくなっていたのを修正
- バージョン行の検索パターンに `v` プレフィックスを追加し、日付抽出を行末の生日付文字列にマッチするよう変更

## Test plan
- [x] `npm run build` が成功することを確認
- [x] ビルド成果物に正しいバージョン(`1.5.1`)・リリース日(`2026-07-26`)が埋め込まれていることを確認
- [x] `tsc -b` の型チェックが通ることを確認