### PR TITLE
perf: Context Providerのvalueをメモ化して不要な再レンダリングを削減

### DIFF
--- a/src/pages/Controller/contexts/ControllerAPIContext.tsx
+++ b/src/pages/Controller/contexts/ControllerAPIContext.tsx
@@ -87,27 +87,39 @@ export const ControllerAPIProvider = ({
     DEFAULT_SETTINGS
   );
 
-  return (
-    <ControllerAPIContext.Provider
-      value={{
-        deckAPIs,
-        setDeckAPI,
-        mixerAPI,
-        setMixerAPI,
-        libraryAPI,
-        setLibraryAPI,
-        midiAPI,
-        midiRequestAccess,
-        midiOpenScriptEditor,
-        historyAPI,
+  const value = useMemo<ControllerAPIContextValue>(
+    () => ({
+      deckAPIs,
+      setDeckAPI,
+      mixerAPI,
+      setMixerAPI,
+      libraryAPI,
+      setLibraryAPI,
+      midiAPI,
+      midiRequestAccess,
+      midiOpenScriptEditor,
+      historyAPI,
 
-        settings,
-        setSettings,
-      }}
-    >
-      {children}
-    </ControllerAPIContext.Provider>
+      settings,
+      setSettings,
+    }),
+    [
+      deckAPIs,
+      setDeckAPI,
+      mixerAPI,
+      setMixerAPI,
+      libraryAPI,
+      setLibraryAPI,
+      midiAPI,
+      midiRequestAccess,
+      midiOpenScriptEditor,
+      historyAPI,
+      settings,
+      setSettings,
+    ]
   );
+
+  return <ControllerAPIContext.Provider value={value}>{children}</ControllerAPIContext.Provider>;
 };
 
 export const useControllerAPIContext = () => {

--- a/src/pages/Controller/contexts/YouTubeDataContext/index.tsx
+++ b/src/pages/Controller/contexts/YouTubeDataContext/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useMemo } from "react";
 import setupIndexedDB from "use-indexeddb";
 import { dbConfig } from "./dbConfig";
 import { useTitleCache } from "./hooks/useTitleCache";
@@ -29,17 +29,20 @@ export const YouTubeDataProvider = ({ children }: YouTubeDataProviderProps) => {
   const { fetchTitle } = useYouTubeTitleFetch();
   const { count, refresh, clear } = useTitleCache();
 
+  const youTubeDataValue = useMemo<YouTubeDataContextValue>(() => ({ fetchTitle }), [fetchTitle]);
+
+  const titleCacheValue = useMemo<TitleCacheContextValue>(
+    () => ({
+      titleCacheCount: count,
+      refreshTitleCacheCount: refresh,
+      clearTitleCache: clear,
+    }),
+    [count, refresh, clear]
+  );
+
   return (
-    <YouTubeDataContext.Provider value={{ fetchTitle }}>
-      <TitleCacheContext.Provider
-        value={{
-          titleCacheCount: count,
-          refreshTitleCacheCount: refresh,
-          clearTitleCache: clear,
-        }}
-      >
-        {children}
-      </TitleCacheContext.Provider>
+    <YouTubeDataContext.Provider value={youTubeDataValue}>
+      <TitleCacheContext.Provider value={titleCacheValue}>{children}</TitleCacheContext.Provider>
     </YouTubeDataContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- `ControllerAPIContext` の Provider `value` を `useMemo` 化。Deck×2・Mixer・Library・Settings・StatusBar 等、広範囲のコンポーネントが消費するcontextのため、無関係な状態変化での再レンダリング連鎖を防ぐ
- `YouTubeDataContext` / `TitleCacheContext` の Provider `value` も `useMemo` 化。`VideoList` の行数分マウントされる `ListItem` への波及を抑える

## Test plan
- [x] `npm run fix`
- [x] `npm run type-check`
- [x] ブラウザでの動作確認