### PR TITLE
ci: add Discord notification on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
 
       - name: Record pre-bump HEAD
         id: pre_bump
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -67,3 +69,35 @@ jobs:
           tag_name: ${{ steps.release.outputs.version }}
           name: ${{ steps.release.outputs.version }}
           body: ${{ steps.changelog.outputs.stdout }}
+
+      - name: Determine bump type
+        id: bump_type
+        if: steps.bumped.outputs.released == 'true'
+        env:
+          PRE_VERSION: ${{ steps.pre_bump.outputs.version }}
+          NEW_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          IFS='.' read -r prev_major prev_minor _ <<< "${PRE_VERSION#v}"
+          IFS='.' read -r new_major new_minor _ <<< "${NEW_VERSION#v}"
+          if [ "$new_major" != "$prev_major" ] || [ "$new_minor" != "$prev_minor" ]; then
+            echo "type=major_minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Discord
+        if: steps.bumped.outputs.released == 'true'
+        env:
+          DISCORD_WEBHOOK_URL_MAJOR_MINOR: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL_MAJOR_MINOR }}
+          DISCORD_WEBHOOK_URL_PATCH: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL_PATCH }}
+          BUMP_TYPE: ${{ steps.bump_type.outputs.type }}
+        run: |
+          if [ "$BUMP_TYPE" = "patch" ]; then
+            WEBHOOK_URL="$DISCORD_WEBHOOK_URL_PATCH"
+          else
+            WEBHOOK_URL="$DISCORD_WEBHOOK_URL_MAJOR_MINOR"
+          fi
+          curl --fail --silent --show-error \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": \"バージョン ${{ steps.release.outputs.version }} がリリースされました!\"}" \
+            "$WEBHOOK_URL"


### PR DESCRIPTION
## Summary

- リリースが実際に発生した場合(`steps.bumped.outputs.released == 'true'`)のみ、Discord へ簡易通知を送るステップを `release.yml` に追加
- メッセージにはリリースされたバージョン番号 (`steps.release.outputs.version`) を含める
- バンプ前後のバージョンを比較し、major/minor の変化を伴うリリースと patch のみのリリースで通知先の Discord WebHook を分ける
- WebHook URL はハードコードせず、GitHub Secret 経由で参照する

## 必要な設定作業(マージ前にユーザー側で実施)

このワークフローは Discord WebHook URL を以下 2 つの GitHub Secret として参照します。以下の手順で登録してください(Claude 側では登録しません)。

- `DISCORD_RELEASE_WEBHOOK_URL_MAJOR_MINOR` — major または minor バージョンアップ時の通知先
- `DISCORD_RELEASE_WEBHOOK_URL_PATCH` — patch バージョンアップ時の通知先

1. Discord のチャンネル設定 → 連携サービス → ウェブフック から WebHook URL を発行(通知先を分ける場合は別チャンネル分の発行が必要)
2. リポジトリの Settings → Secrets and variables → Actions → New repository secret
3. 上記 2 つの Name / Value をそれぞれ登録

登録が完了するまで、通知ステップは実行時にエラーになります(`released == 'true'` の場合のみ実行されるため、通常のリリースが無い限り影響はありません)。

## Test plan

- [ ] `DISCORD_RELEASE_WEBHOOK_URL_MAJOR_MINOR` / `DISCORD_RELEASE_WEBHOOK_URL_PATCH` を secret に登録
- [ ] `workflow_dispatch` で `release` ワークフローを手動実行し、patch バージョンアップ時に `DISCORD_RELEASE_WEBHOOK_URL_PATCH` 側へ通知が届くことを確認
- [ ] minor もしくは major バージョンアップ時に `DISCORD_RELEASE_WEBHOOK_URL_MAJOR_MINOR` 側へ通知が届くことを確認