### PR TITLE
feat: シークバーホバー時に再生時間表示をカーソル位置に連動

### DIFF
--- a/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
+++ b/src/pages/Controller/components/Deck/components/SeekBar/index.tsx
@@ -16,6 +16,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
 
   const barRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
+  const timeRef = useRef<HTMLSpanElement>(null);
   const currentTimeRef = useRef(displayTime);
   const cursorPositionRef = useRef<number | null>(null);
 
@@ -24,14 +25,19 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
   useEffect(() => {
     let animationId: number;
     let lastDisplaySecond = Math.floor(currentTimeFunc());
+    let lastTimeTextSecond: number | null = null;
 
-    const updateIndicator = (position: number) => {
-      if (!indicatorRef.current) {
-        return;
+    const updateIndicatorAndTime = (effectiveRatio: number, currentDuration: number) => {
+      if (indicatorRef.current) {
+        indicatorRef.current.style.left = `${effectiveRatio * 100}%`;
       }
-      const indicatorPosition =
-        cursorPositionRef.current !== null ? cursorPositionRef.current * 100 : position;
-      indicatorRef.current.style.left = `${indicatorPosition}%`;
+      if (timeRef.current) {
+        const flooredSecond = Math.floor(effectiveRatio * currentDuration);
+        if (flooredSecond !== lastTimeTextSecond) {
+          lastTimeTextSecond = flooredSecond;
+          timeRef.current.textContent = formatTime(flooredSecond);
+        }
+      }
     };
 
     const update = () => {
@@ -39,12 +45,13 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       currentTimeRef.current = time;
 
       const currentDuration = durationFunc();
-      const position = toPercentage(time, currentDuration);
+      const actualRatio = currentDuration > 0 ? time / currentDuration : 0;
+      const effectiveRatio = cursorPositionRef.current ?? actualRatio;
 
       if (barRef.current) {
-        barRef.current.style.width = `${position}%`;
+        barRef.current.style.width = `${actualRatio * 100}%`;
       }
-      updateIndicator(position);
+      updateIndicatorAndTime(effectiveRatio, currentDuration);
 
       const currentSecond = Math.floor(time);
       if (currentSecond !== lastDisplaySecond) {
@@ -92,7 +99,7 @@ const SeekBar = ({ currentTimeFunc, durationFunc, hotCues, loopMarkers, onSeek }
       <div className={styles.bar} data-seek-bar ref={barRef} />
       <div className={styles.indicator} data-seek-indicator ref={indicatorRef} />
       <div className={styles.time} data-seek-time>
-        <span>{formatTime(displayTime)}</span>
+        <span ref={timeRef} />
         <span>{formatTime(duration)}</span>
       </div>
       <div className={styles.hotcues}>


### PR DESCRIPTION
## 背景

SeekBarでマウスカーソルをバー上に合わせるとindicator（バー上の再生位置表示）はカーソル位置に追従するが、時間表示（`.time`内の現在時間テキスト）は追従せず実際の再生時間のままだった。

## 変更内容

- 現在時間の`<span>`にrefを追加し、indicatorと同様に毎フレームのrAFループ内でDOM操作により表示を更新するようにした
- ホバー中（`cursorPositionRef`が非null）はカーソル位置に対応する時間（カーソル位置の割合 × duration）を表示し、バーから離れると実際の再生時間表示に戻る
- 既存の「毎フレーム変化する値はReactの再レンダリングを介さずrefで直接DOM操作する」方針を踏襲し、`displayTime`のstate更新（1秒粒度）はそのまま維持

## Test plan

- [ ] SeekBar上でマウスを動かし、時間表示がカーソル位置に連動して変化することを確認
- [ ] マウスをバーから離すと、実際の再生時間表示に戻ることを確認
- [ ] 再生中も通常通り時間表示が更新されることを確認