### PR TITLE
perf: gate rAF sync loop by loop-playback state

### DIFF
--- a/src/components/VJPlayer/hooks/usePlayerSync/index.ts
+++ b/src/components/VJPlayer/hooks/usePlayerSync/index.ts
@@ -100,6 +100,11 @@ export const usePlayerSync = (
     return (syncData.loopEnd - syncData.loopStart) * 1000 * (1 / syncData.playbackRate);
   }, []);
 
+  const hasLoopRange = useCallback(() => {
+    const syncData = syncDataRef.current;
+    return syncData.loopStart != null && syncData.loopEnd != null;
+  }, []);
+
   const loop = useCallback(() => {
     const syncData = syncDataRef.current;
 
@@ -113,8 +118,13 @@ export const usePlayerSync = (
         _sync();
       }
     }
-    animationFrameIdRef.current = requestAnimationFrame(loop);
-  }, [_sync, isNeedLoopAdjust, calculateLoopAdjustTime]);
+
+    if (hasLoopRange() || isSyncingRef.current) {
+      animationFrameIdRef.current = requestAnimationFrame(loop);
+    } else {
+      animationFrameIdRef.current = null;
+    }
+  }, [_sync, isNeedLoopAdjust, calculateLoopAdjustTime, hasLoopRange]);
 
   const startLoop = useCallback(() => {
     if (animationFrameIdRef.current !== null) {
@@ -131,29 +141,21 @@ export const usePlayerSync = (
     animationFrameIdRef.current = null;
   }, []);
 
-  const hasLoopRange = useCallback(() => {
-    const syncData = syncDataRef.current;
-    return syncData.loopStart != null && syncData.loopEnd != null;
-  }, []);
-
   useEffect(() => {
     if (hasLoopRange()) {
       startLoop();
     }
 
     const interval = setInterval(() => {
-      if (animationFrameIdRef.current !== null) {
-        isSyncingRef.current = true;
-      } else {
-        _sync();
-      }
+      isSyncingRef.current = true;
+      startLoop();
     }, SYNC_CONFIG.interval);
 
     return () => {
       stopLoop();
       clearInterval(interval);
     };
-  }, [_sync, startLoop, stopLoop, hasLoopRange]);
+  }, [startLoop, stopLoop, hasLoopRange]);
 
   const markSourceLoaded = useCallback(() => {
     isSourceLoadingRef.current = false;
@@ -181,7 +183,8 @@ export const usePlayerSync = (
         }
       }
 
-      if (syncData.loopStart != null && syncData.loopEnd != null) {
+      const isLoopSet = syncData.loopStart != null && syncData.loopEnd != null;
+      if (isLoopSet || isSyncingRef.current) {
         startLoop();
       } else {
         stopLoop();

--- a/src/components/VJPlayer/hooks/usePlayerSync/index.ts
+++ b/src/components/VJPlayer/hooks/usePlayerSync/index.ts
@@ -24,13 +24,19 @@ export const usePlayerSync = (
   const syncDataRef = useRef<VJSyncData>(INITIAL_SYNC_DATA);
   const isSyncingRef = useRef<boolean>(false);
   const isSourceLoadingRef = useRef(true);
+  const animationFrameIdRef = useRef<number | null>(null);
 
   const { getExpectedCurrentTime, setDuration } = useTimeSync(syncDataRef);
+
+  const setPlayerPlaybackRate = useCallback(
+    (rate: number) => playerRef.current?.setPlaybackRate(rate) ?? false,
+    [playerRef]
+  );
 
   const { calculateAdjustmentRate, applyPlaybackRateAdjustment, syncPlaybackRate } =
     usePlaybackRateAdjustment({
       syncDataRef,
-      setPlaybackRate: (rate: number) => playerRef.current?.setPlaybackRate(rate) ?? false,
+      setPlaybackRate: setPlayerPlaybackRate,
     });
 
   const _sync = useCallback(() => {
@@ -74,80 +80,115 @@ export const usePlayerSync = (
     applyPlaybackRateAdjustment,
   ]);
 
+  const isNeedLoopAdjust = useCallback(() => {
+    const syncData = syncDataRef.current;
+    if (syncData.loopStart == null || syncData.loopEnd == null) {
+      return false;
+    }
+    const expectedCurrentTime = getExpectedCurrentTime();
+    if (expectedCurrentTime === null) {
+      return false;
+    }
+    return syncData.loopEnd < expectedCurrentTime;
+  }, [getExpectedCurrentTime]);
+
+  const calculateLoopAdjustTime = useCallback(() => {
+    const syncData = syncDataRef.current;
+    if (syncData.loopStart == null || syncData.loopEnd == null) {
+      throw new Error("loopStart or loopEnd is not set");
+    }
+    return (syncData.loopEnd - syncData.loopStart) * 1000 * (1 / syncData.playbackRate);
+  }, []);
+
+  const loop = useCallback(() => {
+    const syncData = syncDataRef.current;
+
+    if (!syncData.paused && !isSourceLoadingRef.current) {
+      if (isNeedLoopAdjust()) {
+        syncData.baseTime += calculateLoopAdjustTime();
+        isSyncingRef.current = true;
+      }
+
+      if (isSyncingRef.current) {
+        _sync();
+      }
+    }
+    animationFrameIdRef.current = requestAnimationFrame(loop);
+  }, [_sync, isNeedLoopAdjust, calculateLoopAdjustTime]);
+
+  const startLoop = useCallback(() => {
+    if (animationFrameIdRef.current !== null) {
+      return;
+    }
+    animationFrameIdRef.current = requestAnimationFrame(loop);
+  }, [loop]);
+
+  const stopLoop = useCallback(() => {
+    if (animationFrameIdRef.current === null) {
+      return;
+    }
+    cancelAnimationFrame(animationFrameIdRef.current);
+    animationFrameIdRef.current = null;
+  }, []);
+
+  const hasLoopRange = useCallback(() => {
+    const syncData = syncDataRef.current;
+    return syncData.loopStart != null && syncData.loopEnd != null;
+  }, []);
+
   useEffect(() => {
-    const isNeedLoopAdjust = () => {
-      const syncData = syncDataRef.current;
-      if (syncData.loopStart == null || syncData.loopEnd == null) {
-        return false;
-      }
-      const expectedCurrentTime = getExpectedCurrentTime();
-      if (expectedCurrentTime === null) {
-        return false;
-      }
-      return syncData.loopEnd < expectedCurrentTime;
-    };
-
-    const calculateLoopAdjustTime = () => {
-      const syncData = syncDataRef.current;
-      if (syncData.loopStart == null || syncData.loopEnd == null) {
-        throw new Error("loopStart or loopEnd is not set");
-      }
-      return (syncData.loopEnd - syncData.loopStart) * 1000 * (1 / syncData.playbackRate);
-    };
-
-    let animationFrameId = 0;
-    const loop = () => {
-      const syncData = syncDataRef.current;
-
-      if (!syncData.paused && !isSourceLoadingRef.current) {
-        if (isNeedLoopAdjust()) {
-          syncData.baseTime += calculateLoopAdjustTime();
-          isSyncingRef.current = true;
-        }
-
-        if (isSyncingRef.current) {
-          _sync();
-        }
-      }
-      animationFrameId = requestAnimationFrame(loop);
-    };
-    animationFrameId = requestAnimationFrame(loop);
+    if (hasLoopRange()) {
+      startLoop();
+    }
 
     const interval = setInterval(() => {
-      isSyncingRef.current = true;
+      if (animationFrameIdRef.current !== null) {
+        isSyncingRef.current = true;
+      } else {
+        _sync();
+      }
     }, SYNC_CONFIG.interval);
 
     return () => {
-      cancelAnimationFrame(animationFrameId);
+      stopLoop();
       clearInterval(interval);
     };
-  }, [_sync, getExpectedCurrentTime]);
+  }, [_sync, startLoop, stopLoop, hasLoopRange]);
 
   const markSourceLoaded = useCallback(() => {
     isSourceLoadingRef.current = false;
     isSyncingRef.current = false;
   }, []);
 
-  const notifySyncData = useCallback((syncData: VJSyncData) => {
-    const beforeSyncData = syncDataRef.current;
-    const sourceChanged = hasSourceChanged(syncData.source, beforeSyncData.source);
+  const notifySyncData = useCallback(
+    (syncData: VJSyncData) => {
+      const beforeSyncData = syncDataRef.current;
+      const sourceChanged = hasSourceChanged(syncData.source, beforeSyncData.source);
 
-    syncDataRef.current = syncData;
+      syncDataRef.current = syncData;
 
-    if (sourceChanged) {
-      isSourceLoadingRef.current = true;
-      isSyncingRef.current = false;
-    } else {
-      const needTimingSync =
-        syncData.baseTime !== beforeSyncData.baseTime ||
-        syncData.currentTime !== beforeSyncData.currentTime ||
-        syncData.playbackRate !== beforeSyncData.playbackRate;
+      if (sourceChanged) {
+        isSourceLoadingRef.current = true;
+        isSyncingRef.current = false;
+      } else {
+        const needTimingSync =
+          syncData.baseTime !== beforeSyncData.baseTime ||
+          syncData.currentTime !== beforeSyncData.currentTime ||
+          syncData.playbackRate !== beforeSyncData.playbackRate;
 
-      if (needTimingSync) {
-        isSyncingRef.current = true;
+        if (needTimingSync) {
+          isSyncingRef.current = true;
+        }
       }
-    }
-  }, []);
+
+      if (syncData.loopStart != null && syncData.loopEnd != null) {
+        startLoop();
+      } else {
+        stopLoop();
+      }
+    },
+    [startLoop, stopLoop]
+  );
 
   return {
     getCurrentTime: getExpectedCurrentTime,


### PR DESCRIPTION
## Summary
- VJPlayer はプレビュー2台 + Projection2台の最大4インスタンスが同時にマウントされ、`usePlayerSync` の requestAnimationFrame ループが毎フレーム常時回り続けていた
- rAF ループの毎フレーム処理は実質「ループ境界チェック」と「同期の収束処理（速度調整）」で、ループ再生していないデッキ・同期が収束済みのデッキでは rAF ループを起動しないよう変更した
- `loopStart`/`loopEnd` が設定されている（ループ再生中の）デッキでは、境界チェックのため常時 rAF を有効化する
- 通常再生中は、1 秒間隔の `setInterval` が同期トリガー（`isSyncingRef`）をセットし、その間だけ rAF ループを起動して毎フレーム `_sync()` による速度調整を行い、収束（`syncThreshold` 以内）したら rAF を自動停止する。ループの ON/OFF・同期トリガーの発生に応じて `notifySyncData` / `setInterval` から rAF の起動・停止を動的に切り替える
- 副次的な修正: `usePlaybackRateAdjustment` に渡す `setPlaybackRate` がインライン関数で毎レンダー再生成されており、`_sync` → `loop` → `startLoop`/`stopLoop` の参照が不安定になっていた。これにより `useEffect` の依存配列変化のたびに `stopLoop` が呼ばれ、rAF ループの動的 start/stop が機能しないバグがあったため `useCallback` で安定化した

## 検証結果
- `npm run qa`（fix + type-check + build）通過
- dev サーバー上で実際に動画を再生し確認:
  - 通常再生（ループ未設定・同期収束後）: rAF ループが起動していないことを確認
  - `setLoopStart`/`setLoopEnd` でループ設定: rAF ループが起動することを確認
  - `clearLoop` でループ解除: rAF ループが停止することを確認
  - ループ境界（2〜6秒）を設定し数秒待機: `baseTime` 加算によるループ境界チェックが機能し、再生位置がループ範囲内で正しく巻き戻ることを確認
  - `currentTime` を 300ms 間隔でポーリングし実効再生速度を算出: 通常再生・ループ再生・ループ解除後のいずれも 1.0 ± 0.3% 程度で安定していることを確認（初回実装では 1 秒間隔でしか速度調整が行われず、再生がガクつく回帰があったため追加コミットで修正済み）